### PR TITLE
Update Rubinius gem dependencies, Travis label.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,5 @@ rvm:
   - 1.9.2
   - 1.9.3
   - 2.0.0
-  - jruby-18mode
   - jruby-19mode
-  - rbx-18mode
-  - rbx-19mode
-branches:
-  only:
-    - master
+  - rbx

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,8 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in zonebie.gemspec
 gemspec
+
+platforms :rbx do
+  gem 'rubysl', '~> 2.0'
+  gem 'rubinius-developer_tools'
+end


### PR DESCRIPTION
Removed jruby-18mode and now obsolete rbx-18mode and rbx-19mode from .travis.yml

Add rbx label to .travis.yml
Add rbx gems to Gemfile
