### PR TITLE
Zone info from Wikipedia

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,17 @@ seems present in one zone), set the `ZONEBIE_TZ` environment variable:
 ZONEBIE_TZ="Eastern Time (US & Canada)" rake
 ```
 
+## Timezone Info
+
+To print out a paragraph from Wikipedia (if available) about each timezone
+set the `ZONEBIE_INFO` environment variable before your tests run. Then in an
+after hook you just need to call `Zonebie.print_timezone_info` to print the
+information to STDOUT. This is already included in `zonebie/rspec`.
+
+Data is collected in a new thread so shouldn't slow down your tests by too
+much. The `wikipedia-client` gem must be in your Gemfile for this feature
+to work.
+
 ## Contributing
 
 1. Fork it

--- a/README.md
+++ b/README.md
@@ -106,12 +106,12 @@ ZONEBIE_TZ="Eastern Time (US & Canada)" rake
 
 ## Timezone Info
 
-To print out a paragraph from Wikipedia (if available) about each timezone
+To print out a paragraph from Wikipedia (if available) about the random timezone,
 set the `ZONEBIE_INFO` environment variable before your tests run. Then in an
 after hook you just need to call `Zonebie.print_timezone_info` to print the
 information to STDOUT. This is already included in `zonebie/rspec`.
 
-Data is collected in a new thread so shouldn't slow down your tests by too
+Data is collected in a separate thread so shouldn't slow down your tests by too
 much. The `wikipedia-client` gem must be in your Gemfile for this feature
 to work.
 

--- a/lib/zonebie.rb
+++ b/lib/zonebie.rb
@@ -1,5 +1,5 @@
 require File.expand_path("zonebie/version", File.dirname(__FILE__))
-require 'zonebie/zone_info'
+require "zonebie/zone_info"
 
 module Zonebie
   class << self
@@ -38,8 +38,8 @@ module Zonebie
     end
 
     def set_random_timezone
-      zone = ENV['ZONEBIE_TZ'] || random_timezone
-      load_from_wikipedia(zone) if ENV['ZONEBIE_INFO']
+      zone = ENV["ZONEBIE_TZ"] || random_timezone
+      load_from_wikipedia(zone) if ENV["ZONEBIE_INFO"]
 
       $stdout.puts("[Zonebie] Setting timezone: ZONEBIE_TZ=\"#{zone}\"") unless quiet
       backend.zone = zone

--- a/lib/zonebie.rb
+++ b/lib/zonebie.rb
@@ -1,4 +1,5 @@
 require File.expand_path("zonebie/version", File.dirname(__FILE__))
+require 'zonebie/zone_info'
 
 module Zonebie
   class << self
@@ -38,6 +39,7 @@ module Zonebie
 
     def set_random_timezone
       zone = ENV['ZONEBIE_TZ'] || random_timezone
+      load_from_wikipedia(zone) if ENV['ZONEBIE_INFO']
 
       $stdout.puts("[Zonebie] Setting timezone: ZONEBIE_TZ=\"#{zone}\"") unless quiet
       backend.zone = zone

--- a/lib/zonebie/rspec.rb
+++ b/lib/zonebie/rspec.rb
@@ -4,4 +4,9 @@ RSpec.configure do |c|
   c.before(:suite) do
     Zonebie.set_random_timezone
   end
+  if ENV["ZONEBIE_INFO"]
+    c.after(:suite) do
+      Zonebie.print_timezone_info
+    end
+  end
 end

--- a/lib/zonebie/zone_info.rb
+++ b/lib/zonebie/zone_info.rb
@@ -3,7 +3,12 @@ module Zonebie
     def load_from_wikipedia(zone)
       require 'wikipedia'
       @request = Thread.new {
-        Wikipedia.find(zone).text.split("\n").first
+        text = Wikipedia.find(zone).text
+        if text
+          text.split("\n").first
+        else
+          "No infomration available for #{zone}"
+        end
       }
     rescue LoadError
       @request = :load_error
@@ -16,7 +21,7 @@ module Zonebie
       when :load_error
         $stderr.puts 'Please install the wikipedia-client gem to download zone info'
       else 
-        $stdout.puts @request.join.value
+        $stdout.puts "", @request.join.value
       end
     end
   end

--- a/lib/zonebie/zone_info.rb
+++ b/lib/zonebie/zone_info.rb
@@ -7,7 +7,7 @@ module Zonebie
         if text
           text.split("\n").first
         else
-          "No infomration available for #{zone}"
+          "No information available for #{zone}"
         end
       }
     rescue LoadError
@@ -17,9 +17,9 @@ module Zonebie
     def print_timezone_info
       case @request
       when nil
-        $stderr.puts "Please set the ZONEBIE_INFO environment variable to load data from Wikipedia"
+        $stderr.puts "", "Please set the ZONEBIE_INFO environment variable to load data from Wikipedia"
       when :load_error
-        $stderr.puts "Please install the wikipedia-client gem to download zone info"
+        $stderr.puts "", "Please install the wikipedia-client gem to download zone info"
       else 
         $stdout.puts "", @request.join.value
       end

--- a/lib/zonebie/zone_info.rb
+++ b/lib/zonebie/zone_info.rb
@@ -1,7 +1,7 @@
 module Zonebie
   class << self
     def load_from_wikipedia(zone)
-      require 'wikipedia'
+      require "wikipedia"
       @request = Thread.new {
         text = Wikipedia.find(zone).text
         if text
@@ -17,9 +17,9 @@ module Zonebie
     def print_timezone_info
       case @request
       when nil
-        $stderr.puts 'Please set the ZONEBIE_INFO environment variable to load data from Wikipedia'
+        $stderr.puts "Please set the ZONEBIE_INFO environment variable to load data from Wikipedia"
       when :load_error
-        $stderr.puts 'Please install the wikipedia-client gem to download zone info'
+        $stderr.puts "Please install the wikipedia-client gem to download zone info"
       else 
         $stdout.puts "", @request.join.value
       end

--- a/lib/zonebie/zone_info.rb
+++ b/lib/zonebie/zone_info.rb
@@ -1,0 +1,23 @@
+module Zonebie
+  class << self
+    def load_from_wikipedia(zone)
+      require 'wikipedia'
+      @request = Thread.new {
+        Wikipedia.find(zone).text.split("\n").first
+      }
+    rescue LoadError
+      @request = :load_error
+    end
+
+    def print_timezone_info
+      case @request
+      when nil
+        $stderr.puts 'Please set the ZONEBIE_INFO environment variable to load data from Wikipedia'
+      when :load_error
+        $stderr.puts 'Please install the wikipedia-client gem to download zone info'
+      else 
+        $stdout.puts @request.join.value
+      end
+    end
+  end
+end

--- a/spec/integrations/zone_info_spec.rb
+++ b/spec/integrations/zone_info_spec.rb
@@ -1,0 +1,29 @@
+require "spec_helper"
+require "zonebie/zone_info"
+require 'wikipedia'
+
+describe "#print_timezone_info" do
+  let(:content) { "some wiki info\nsecond paragraph" }
+  let(:expected) { "some wiki info\n" }
+  let(:page) { mock 'page' }
+  let(:out) { StringIO.new }
+
+  before do
+    $stdout.stubs(:puts)
+    Wikipedia.stubs(:find).returns(page)
+    page.stubs(:text).returns content
+    ENV["ZONEBIE_INFO"] = "true"
+    Zonebie.set_random_timezone
+    $stdout = out
+  end
+  
+  after do
+    $stdout = STDOUT
+  end
+
+  it "prints info about the time zone to stdout" do
+    Zonebie.print_timezone_info
+    out.rewind
+    expect(out.read).to eq expected
+  end
+end

--- a/spec/integrations/zone_info_spec.rb
+++ b/spec/integrations/zone_info_spec.rb
@@ -4,7 +4,7 @@ require 'wikipedia'
 
 describe "#print_timezone_info" do
   let(:content) { "some wiki info\nsecond paragraph" }
-  let(:expected) { "some wiki info\n" }
+  let(:expected) { "\nsome wiki info\n" }
   let(:page) { mock 'page' }
   let(:out) { StringIO.new }
 

--- a/spec/lib/zonebie/zone_info_spec.rb
+++ b/spec/lib/zonebie/zone_info_spec.rb
@@ -1,0 +1,107 @@
+require "spec_helper"
+require "wikipedia"
+
+describe Zonebie do
+  let(:page) { mock "page" }
+
+  before do
+    Wikipedia.stubs(:find).returns page
+  end
+
+  describe ".load_from_wikipedia" do
+    context "when there is info on the timezone" do
+      let(:expected) {
+        "Some information about a timezone"
+      }
+
+      before do
+        page.stubs(:text).returns "Some information about a timezone\npara 2\n"
+      end
+
+      it "uses a new thread to request data from wikipedia and returns the first paragraph" do
+        result = Zonebie.load_from_wikipedia "a timezone"
+        expect(result.join.value).to eq expected
+      end
+    end
+
+    context "when there is no info on the timezone" do
+      let(:expected) { 
+        "No information available for a timezone"
+      }
+
+      before do
+        page.stubs(:text).returns nil
+      end
+
+      it "informs that there was no information" do
+        result = Zonebie.load_from_wikipedia "a timezone"
+        expect(result.join.value).to eq expected
+      end
+    end
+  end
+
+  describe ".print_timezone_info" do
+    let(:out) { StringIO.new }
+
+    context "when the request is nil" do 
+      let(:message) {
+        "Please set the ZONEBIE_INFO environment variable to load data from Wikipedia"
+      }
+
+      before do
+        Zonebie.instance_variable_set("@request", nil)
+        $stderr = out
+      end
+
+      after do
+        $stderr = STDERR
+      end
+
+      it "informs the user to set the ZONEBIE_INFO variable" do
+        Zonebie.print_timezone_info
+        out.rewind
+        expect(out.read).to eq "\n#{message}\n"
+      end
+    end
+
+    context "when the request is a load error" do
+      let(:message) {
+        "Please install the wikipedia-client gem to download zone info"
+      }
+
+      before do
+        Zonebie.instance_variable_set("@request", :load_error)
+        $stderr = out
+      end
+
+      after do
+        $stderr = STDERR
+      end
+
+      it "informs the user to install the wikipedia client" do
+        Zonebie.print_timezone_info
+        out.rewind
+        expect(out.read).to eq "\n#{message}\n"
+      end
+    end
+
+    context "when the request succeeds" do
+      let(:t) { Thread.new { 'hello' } }
+
+      before do
+        Zonebie.instance_variable_set "@request", t
+        $stdout = out
+      end
+
+      after do
+        $stdout = STDOUT
+      end
+
+      it "prints the info from wikipedia" do
+        Zonebie.print_timezone_info
+        out.rewind
+        expect(out.read).to eq "\nhello\n"
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ RSpec.configure do |c|
 
   c.before do
     ENV.delete('ZONEBIE_TZ')
+    ENV.delete('ZONEBIE_INFO')
     Zonebie.backend = nil # reset to default
   end
 end

--- a/zonebie.gemspec
+++ b/zonebie.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec", "~>2.14"
   gem.add_development_dependency "mocha", "~>0.14.0"
+  gem.add_development_dependency "wikipedia-client", "~>1.5.0"
 
   gem.add_development_dependency "activesupport", ">=2.3"
   gem.add_development_dependency "tzinfo", "~>1.0", ">= 1.0.1"


### PR DESCRIPTION
This adds an optional extra bit of functionality which spawns a new thread and collects the first paragraph of Wikipedia information about a Timezone and then prints it out afterwards.

The wikipedia-client gem is optional (but needed for development) so users who don't want this can just not install the gem. It is turned on and off using the ZONEBIE_INFO environment variable