### PR TITLE
[BUGFIX] reintroduces `random_timezone` to fix regression

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+## 0.7.0 (UNRELEASED)
+
+* [BUGFIX] reintroduces `random_timezone` to fix regression
+
 ## 0.6.0 (13 March 2016)
 
 * Refactorings (Yuki Matsukura)

--- a/README.md
+++ b/README.md
@@ -111,3 +111,16 @@ ZONEBIE_TZ="Eastern Time (US & Canada)" rake
 3. Commit your changes (`git commit -am 'Added some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)
 5. Create new Pull Request
+
+
+### Testing
+
+Make sure tests pass before submitting pull request. 
+
+Install dependencies:
+
+    $ bundle install
+
+Run tests:
+
+    $ rake

--- a/lib/zonebie.rb
+++ b/lib/zonebie.rb
@@ -39,10 +39,14 @@ module Zonebie
     end
 
     def set_random_timezone
-      zone = ENV['ZONEBIE_TZ'] || backend.zones.sample
+      zone = ENV['ZONEBIE_TZ'] || random_timezone
 
       $stdout.puts("[Zonebie] Setting timezone: ZONEBIE_TZ=\"#{zone}\"") unless quiet
       backend.zone = zone
+    end
+
+    def random_timezone
+      backend.zones.sample
     end
   end
 end

--- a/lib/zonebie/version.rb
+++ b/lib/zonebie/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Zonebie
-  VERSION = '0.6.0'.freeze
+  VERSION = '0.7.0'.freeze
 end

--- a/spec/lib/zonebie_spec.rb
+++ b/spec/lib/zonebie_spec.rb
@@ -90,5 +90,8 @@ describe Zonebie do
       Zonebie.backend = :my_awesome_backend
     end
 
+    it "returns a random timezone" do
+      expect(Zonebie.random_timezone).to eq("Eastern Time (US & Canada)")
+    end
   end
 end


### PR DESCRIPTION
Brings back `random_timezone` public API that was still in use and documented.

Let me know if this looks right.