### PR TITLE
Prevent error if gem is loaded before to activesupport

### DIFF
--- a/lib/zonebie/backends/active_support.rb
+++ b/lib/zonebie/backends/active_support.rb
@@ -1,4 +1,5 @@
 begin
+  require "active_support"
   require "active_support/time"
 rescue LoadError
   # not required; this backend will simply not be used


### PR DESCRIPTION
I had this error

```
‹main*›$ be rspec

An error occurred while loading spec_helper.
Failure/Error: require "zonebie/rspec"

NoMethodError:
  undefined method `deprecator' for module ActiveSupport
# /Users/horacio/.rvm/gems/ruby-3.3.3/gems/activesupport-7.1.4/lib/active_support/core_ext/array/conversions.rb:108:in `<class:Array>'
# /Users/horacio/.rvm/gems/ruby-3.3.3/gems/activesupport-7.1.4/lib/active_support/core_ext/array/conversions.rb:8:in `<top (required)>'
# /Users/horacio/.rvm/gems/ruby-3.3.3/gems/activesupport-7.1.4/lib/active_support/duration.rb:3:in `<top (required)>'
# /Users/horacio/.rvm/gems/ruby-3.3.3/gems/activesupport-7.1.4/lib/active_support/core_ext/time/calculations.rb:3:in `<top (required)>'
# /Users/horacio/.rvm/gems/ruby-3.3.3/gems/activesupport-7.1.4/lib/active_support/core_ext/time.rb:4:in `<top (required)>'
# /Users/horacio/.rvm/gems/ruby-3.3.3/gems/activesupport-7.1.4/lib/active_support/time.rb:12:in `<top (required)>'
# /Users/horacio/.rvm/gems/ruby-3.3.3/gems/zonebie-0.6.1/lib/zonebie/backends/active_support.rb:3:in `<top (required)>'
# /Users/horacio/.rvm/gems/ruby-3.3.3/gems/zonebie-0.6.1/lib/zonebie/backends.rb:1:in `<top (required)>'
# /Users/horacio/.rvm/gems/ruby-3.3.3/gems/zonebie-0.6.1/lib/zonebie.rb:54:in `<top (required)>'
# /Users/horacio/.rvm/gems/ruby-3.3.3/gems/zonebie-0.6.1/lib/zonebie/rspec.rb:1:in `<top (required)>'
# ./spec/rails_helper.rb:8:in `<top (required)>'
# ./spec/spec_helper.rb:3:in `<top (required)>'
No examples found.
```
And this is happening when you try to load the gem before activesupport is loaded. this will prevent this error.